### PR TITLE
Updated Plasma Cash page to remove duplicate text

### DIFF
--- a/src/docs/plasma-cash.html
+++ b/src/docs/plasma-cash.html
@@ -160,12 +160,6 @@
 
             <h3 id="background">Motivation - Operator's Incentive</h3>
             <p>
-              In Plasma MVP, all tokens deposited can be considered as fungible tokens.
-              An exit relies on a user's ability to claim and verify a certain amount of the funds in the shared pool.
-              This results in a scenario where an operator might be able to create "out of nowhere" transactions that do not stem from a valid deposit in the root chain contract.
-              The operator would then intentionally withhold these blocks where invalid transactions exist.
-            </p>
-            <p>
               In Plasma MVP, all tokens deposited are fungible and stored in a shared pool on the root chain contract.
               An exit relies on a user's ability to claim and verify a certain amount of funds and for this claim to be resilient against challenges.
             </p>


### PR DESCRIPTION
It looks like the text in the first paragraph or two were duplicated in the Plasma Cash page. Suggesting to remove one of the sections.