### PR TITLE
Remove target:blank references

### DIFF
--- a/src/docs/intro.html
+++ b/src/docs/intro.html
@@ -176,21 +176,21 @@
             <h3 id="contributing">Contributing</h3>
             <p>
               LearnPlasma is a community effort and a labor of love!
-              The project was started at the <a href="http://www.initc3.org/events/2017-07-13-IC3-Ethereum-Crypto-Boot-Camp-at-Cornell-University.html" target="_blank">2018 IC3-Ethereum Crypto Boot Camp at Cornell University</a>.
-              Most of the content on this website was contributed by people who didn’t know anything about Plasma coming into the boot camp.
+              The project was started at the <a href="http://www.initc3.org/events/2017-07-13-IC3-Ethereum-Crypto-Boot-Camp-at-Cornell-University.html">2018 IC3-Ethereum Crypto Boot Camp at Cornell University</a>.
+              Most of the content on this website was contributed by people who didn’t know anything about Plasma coming into that boot camp.
             </p>
             <p>
-              You can become a contributor to LearnPlasma!
+              You can also become a contributor to LearnPlasma!
               There’s always lots to be done.
-              This entire website is open source and available at the <a href="https://github.com/ethsociety/plasma-website" target="_blank">LearnPlasma GitHub</a> repository.
+              This entire website is open source and available at the <a href="https://github.com/ethsociety/plasma-website">LearnPlasma GitHub</a> repository.
               Please open a GitHub issue if you’re confused about something, want to ask a question, or have any general feedback!
               Want to see content about a specific topic? Open an issue!
-              If you’re unfamiliar with GitHub, we’ve created a simple guide to opening your first issue <a href="../pages/misc.html#github-issues" target="_blank">here</a>.
+              If you’re unfamiliar with GitHub, we’ve created a simple guide to opening your first issue <a href="../pages/misc.html#github-issues">here</a>.
               We also appreciate any pull requests with bug reports, typos, or new content.
             </p>
             <p>
               If you want to contribute code to a Plasma project, we’re maintaining a list of actively developed Plasma implementations and ecosystem projects <a href="../pages/build.html">here</a>.
-              You can learn about the current open research questions and see a list of ways you can contribute <a href="../pages/research.html">here</a>.
+              You can also learn about the current open research questions and see a list of ways you can contribute <a href="../pages/research.html">here</a>.
             </p>
 
             <hr class="hr-dash my-7">
@@ -198,9 +198,9 @@
             <h3 id="community">Community</h3>
             <p>
               Learning alone is no fun!
-              To make the learning process as collaborative as possible, we’ve launched the <a href="https://www.reddit.com/r/learnplasma/" target="_blank">LearnPlasma reddit community</a>.
+              To make the learning process as collaborative as possible, we’ve launched the <a href="https://www.reddit.com/r/learnplasma/">LearnPlasma reddit community</a>.
               There you’ll be able to ask questions and discuss different Plasma-related topics with other people also learning more about Plasma.
-              You can also tweet at the <a href="https://twitter.com/learnplasma" target="_blank">LearnPlasma Twitter account</a> if you’d like to.
+              You can also tweet at the <a href="https://twitter.com/learnplasma">LearnPlasma Twitter account</a> if you’d like to.
             </p>
             <p>
               We're looking for subreddit moderators!

--- a/src/docs/plasma-framework.html
+++ b/src/docs/plasma-framework.html
@@ -157,7 +157,7 @@
             </p>
             <p>
               This framework nature of Plasma can make it hard to explain.
-              The original <a href="http://plasma.io/plasma.pdf" target="_blank">paper</a> describing Plasma runs into this problem too.
+              The original <a href="http://plasma.io/plasma.pdf">paper</a> describing Plasma runs into this problem too.
               It’s difficult to describe exactly what Plasma <i>is</i> without giving examples of how it can be used.
               At the same time, it’s important to remember that those examples are only a very small slice of what’s possible. 
             </p>

--- a/src/index.html
+++ b/src/index.html
@@ -184,7 +184,7 @@
           <div class="row gap-y">
 
             <div class="col-md-8 col-lg-4">
-              <a class="card card-body border hover-shadow-6 text-center py-6" href="https://www.reddit.com/r/learnplasma" target="_blank">
+              <a class="card card-body border hover-shadow-6 text-center py-6" href="https://www.reddit.com/r/learnplasma">
                 <p><i class="fa fa-reddit lead-7 text-lighter"></i></p>
                 <h6 class="mb-0 mt-3">r/learnplasma</h6>
               </a>

--- a/src/pages/build.html
+++ b/src/pages/build.html
@@ -127,7 +127,7 @@
           This page maintains a list of actively developed projects you can contribute to.
         </p>
         <p>
-          If you actively maintain a Plasma implementation and don't see it listed here, feel free to create an issue on <a href="https://github.com/ethsociety/learn-plasma" target="_blank">GitHub!</a>
+          If you actively maintain a Plasma implementation and don't see it listed here, feel free to create an issue on <a href="https://github.com/ethsociety/learn-plasma">GitHub!</a>
           We'll get your project on this page.
           Similarly, please open an issue if something on this page is inaccurate or you'd like to change a description.
         </p>
@@ -195,13 +195,13 @@
     
           <div class="col-md-7 col-xl-8 ml-md-auto py-8">
             <!-- Fourth State Labs -->
-            <h2 id="fourthstatelabs"><a href="https://github.com/fourthstate" target="_blank">FourthState Labs</a></h2>
+            <h2 id="fourthstatelabs"><a href="https://github.com/fourthstate">FourthState Labs</a></h2>
             <p>
               FourthState Labs is Blockchain @ Berkeley's Plasma team.
             </p>
             <br>
     
-            <h5 id="fsl-rootchain"><a href="https://github.com/FourthState/plasma-mvp-rootchain" target="_blank">plasma-mvp-rootchain</a></h5>
+            <h5 id="fsl-rootchain"><a href="https://github.com/FourthState/plasma-mvp-rootchain">plasma-mvp-rootchain</a></h5>
             <p>
               FourthState Labs is maintaining a Plasma MVP smart contract for Ethereum.
             </p>
@@ -212,7 +212,7 @@
             </ul>
             <br>
 
-            <h5 id="fsl-sidechain"><a href="https://github.com/FourthState/plasma-mvp-sidechain" target="_blank">plasma-mvp-sidechain</a></h5>
+            <h5 id="fsl-sidechain"><a href="https://github.com/FourthState/plasma-mvp-sidechain">plasma-mvp-sidechain</a></h5>
             <p>
               FourthState labs is separately developing a Plasma MVP client that uses tendermint consensus.
             </p>
@@ -224,13 +224,13 @@
             <hr class="hr-dash my-7">
 
             <!-- OmiseGO -->
-            <h2 id="omisego"><a href="https://omisego.network/" target="_blank">OmiseGO</a></h2>
+            <h2 id="omisego"><a href="https://omisego.network/">OmiseGO</a></h2>
             <p>
               OmiseGO is using Plasma to build a scalable decentralized exchange and payment network.
             </p>
             <br>
 
-            <h5 id="omg-mvp"><a href="https://github.com/omisego/plasma-contracts" target="_blank">plasma-contracts</a></h5>
+            <h5 id="omg-mvp"><a href="https://github.com/omisego/plasma-contracts">plasma-contracts</a></h5>
             <p>
               OmiseGO's production Plasma contracts are maintained in this repository.
               The master branch currently tracks optimized Plasma MVP contracts.
@@ -242,7 +242,7 @@
             </ul>
             <br>
 
-            <h5 id="omg-contracts"><a href="https://github.com/omisego/plasma-mvp" target="_blank">plasma-mvp</a></h5>
+            <h5 id="omg-contracts"><a href="https://github.com/omisego/plasma-mvp">plasma-mvp</a></h5>
             <p>
               OmiseGO is building out a reference implementation of Plasma MVP as part of their decentralized exchange.
               The contracts in this repo are generally less optimized but more readable.
@@ -254,7 +254,7 @@
             </ul>
             <br>
 
-            <h5 id="omg-cash"><a href="https://github.com/omisego/plasma-cash" target="_blank">plasma-cash</a></h5>
+            <h5 id="omg-cash"><a href="https://github.com/omisego/plasma-cash">plasma-cash</a></h5>
             <p>
               OmiseGO hosts a Plasma Cash contract and client implementation, although the project is largely maintained by outside contributors.
             </p>
@@ -267,13 +267,13 @@
             <hr class="hr-dash my-7">
 
             <!-- Loom Network -->
-            <h2 id="loom"><a href="https://loomx.io/" target="_blank">Loom Network</a></h2>
+            <h2 id="loom"><a href="https://loomx.io/">Loom Network</a></h2>
             <p>
               Loom uses Plasma to augment their application-specific sidechains (DAppChains).
             </p>
             <br>
       
-            <h5 id="loom-cash"><a href="https://github.com/loomnetwork/plasma-erc721" target="_blank">plasma-erc721</a></h5>
+            <h5 id="loom-cash"><a href="https://github.com/loomnetwork/plasma-erc721">plasma-erc721</a></h5>
             <p>
               Loom is planning to use Plasma Cash to secure non-fungible assets on their DAppChains.
             </p>
@@ -288,13 +288,13 @@
             <hr class="hr-dash my-7">
 
             <!-- BANKEX -->
-            <h2 id="bankex"><a href="https://bankex.com/en/" target="_blank">BANKEX</a></h2>
+            <h2 id="bankex"><a href="https://bankex.com/en/">BANKEX</a></h2>
             <p>
               BANKEX is working on Plasma as part of their tokenization ecosystem.
             </p>
             <br>
       
-            <h5 id="bx-mvp"><a href="https://github.com/BANKEX/PlasmaParentContract" target="_blank">PlasmaParentContract</a></h5>
+            <h5 id="bx-mvp"><a href="https://github.com/BANKEX/PlasmaParentContract">PlasmaParentContract</a></h5>
             <p>
               BANKEX currently maintains an experimental implementation of More Viable Plasma. 
             </p>
@@ -307,13 +307,13 @@
             <hr class="hr-dash my-7">
 
             <!-- Wolk -->
-            <h2 id="wolk"><a href="https://www.wolk.com/" target="_blank">Wolk</a></h2>
+            <h2 id="wolk"><a href="https://www.wolk.com/">Wolk</a></h2>
             <p>
               Wolk is incorporating Plasma Cash as part of their decentralized database service architecture.
             </p>
             <br>
       
-            <h5 id="wolk-cash"><a href="https://github.com/wolkdb/deepblockchains/tree/master/Plasmacash" target="_blank">Plasmacash</a></h5>
+            <h5 id="wolk-cash"><a href="https://github.com/wolkdb/deepblockchains/tree/master/Plasmacash">Plasmacash</a></h5>
             <p>
               Wolk maintains an implementation of Plasma Cash root chain contracts.
             </p>
@@ -325,13 +325,13 @@
             <hr class="hr-dash my-7">
 
             <!-- Lucidity -->
-            <h2 id="lucidity"><a href="https://lucidity.tech/" target="_blank">Lucidity</a></h2>
+            <h2 id="lucidity"><a href="https://lucidity.tech/">Lucidity</a></h2>
             <p>
               Lucidity is using Plasma Cash coupled with a stable coin for payments in AdTech supply chains.
             </p>
             <br>
       
-            <h5 id="lucidity-plasma-mvp"><a href="https://github.com/luciditytech/lucidity-plasma" target="_blank">Plasma MVP</a></h5>
+            <h5 id="lucidity-plasma-mvp"><a href="https://github.com/luciditytech/lucidity-plasma">Plasma MVP</a></h5>
             <p>
               Lucidity maintains an implementation of Plasma MVP root chain contracts.
               Particularly implements UTXO model for mass-exists.
@@ -343,7 +343,7 @@
             </ul>
             <br>
 
-            <h5 id="lucidity-plasma-cash"><a href="https://github.com/luciditytech/lucidity-plasma-cash" target="_blank">Plasma Cash</a></h5>
+            <h5 id="lucidity-plasma-cash"><a href="https://github.com/luciditytech/lucidity-plasma-cash">Plasma Cash</a></h5>
             <p>
               Lucidity maintains an implementation of Plasma Cash as part of their sidechain architecture.
               This repo contains a Sparse Merkle Tree implementation used for multi-party crypto payments in AdTech supply chains.

--- a/src/pages/research.html
+++ b/src/pages/research.html
@@ -109,7 +109,7 @@
         </p>
         <p>
           Researching something cool and Plasma related?
-          Open an issue <a href="https://github.com/ethsociety/learn-plasma/issues" target="_blank">here</a> and we'll publish the relevant information to this page.
+          Open an issue <a href="https://github.com/ethsociety/learn-plasma/issues">here</a> and we'll publish the relevant information to this page.
         </p>
       </div>
     </header><!-- /.header -->
@@ -184,7 +184,7 @@
             </p>
             <p>
               Some research has gone into repeatedly reusing Ethereum memory space to make commitments more efficient.
-              Check out this post on <a href="https://ethresear.ch/t/double-batched-merkle-log-accumulators-for-efficient-plasma-commitments/2313" target="_blank">Merkle Mountain Ranges</a> in Plasma for an example.
+              Check out this post on <a href="https://ethresear.ch/t/double-batched-merkle-log-accumulators-for-efficient-plasma-commitments/2313">Merkle Mountain Ranges</a> in Plasma for an example.
               This cuts down the commitment cost by about 50%, but that's still not perfect.
             </p>
             <h6>Research Questions:</h6>
@@ -195,9 +195,9 @@
             </ul>
             <h6>Resources:</h6>
             <ul>
-              <li><a href="https://github.com/opentimestamps/opentimestamps-server/blob/master/doc/merkle-mountain-range.md" target="_blank">Merkle Mountain Ranges</a></li>
-              <li><a href="https://ethresear.ch/t/double-batched-merkle-log-accumulator/571" target="_blank">Double-batched Merkle log accumulator</a></li>
-              <li><a href="https://ethresear.ch/t/double-batched-merkle-log-accumulators-for-efficient-plasma-commitments/2313" target="_blank">Double Batched Merkle Log Accumulators for Efficient Plasma Commitments</a></li>
+              <li><a href="https://github.com/opentimestamps/opentimestamps-server/blob/master/doc/merkle-mountain-range.md">Merkle Mountain Ranges</a></li>
+              <li><a href="https://ethresear.ch/t/double-batched-merkle-log-accumulator/571">Double-batched Merkle log accumulator</a></li>
+              <li><a href="https://ethresear.ch/t/double-batched-merkle-log-accumulators-for-efficient-plasma-commitments/2313">Double Batched Merkle Log Accumulators for Efficient Plasma Commitments</a></li>
             </ul>
             <br>
     
@@ -242,8 +242,8 @@
             </ul>
             <h6>Resources:</h6>
             <ul>
-              <li><a href="https://blog.ethereum.org/2016/05/09/on-settlement-finality/" target="_blank">On Settlement Finality</a></li>
-              <li><a href="https://github.com/omisego/research/issues/29" target="_blank">Cryptoeconomic finality</a></li>
+              <li><a href="https://blog.ethereum.org/2016/05/09/on-settlement-finality/">On Settlement Finality</a></li>
+              <li><a href="https://github.com/omisego/research/issues/29">Cryptoeconomic finality</a></li>
             </ul>
             <br>
     
@@ -275,7 +275,7 @@
             </ul>
             <h6>Resources:</h6>
             <ul>
-              <li><a href="https://blog.ethereum.org/2016/05/09/on-settlement-finality/" target="_blank">Math: Plasma MVP vs. Plasma Cash</a></li>
+              <li><a href="https://blog.ethereum.org/2016/05/09/on-settlement-finality/">Math: Plasma MVP vs. Plasma Cash</a></li>
             </ul>
             <br>
     
@@ -283,7 +283,7 @@
             <p>
               Zero knowledge succinct arguments of knowledge (or zk-SNARKs) are a relatively recent technological development.
               Basically, they allow us to create certain general purpose programs that can keep information secret.
-              Vitalik's <a href="" target="_blank">blog post</a> on zk-SNARKs is a great place to start if you're unfamiliar with how they work.
+              Vitalik's <a href="">blog post</a> on zk-SNARKs is a great place to start if you're unfamiliar with how they work.
             </p>
             <p>
               Some work has been done exploring the utility of zk-SNARKs in Plasma.
@@ -308,15 +308,15 @@
             </ul>
             <h6>Resources:</h6>
             <ul>
-              <li><a href="https://medium.com/@VitalikButerin/zk-snarks-under-the-hood-b33151a013f6" target="_blank">Zk-SNARKs: Under the Hood</a></li>
-              <li><a href="https://ethresear.ch/t/plasma-is-plasma/2195" target="_blank">Zk-SNARKs for Plasma</a></li>
+              <li><a href="https://medium.com/@VitalikButerin/zk-snarks-under-the-hood-b33151a013f6">Zk-SNARKs: Under the Hood</a></li>
+              <li><a href="https://ethresear.ch/t/plasma-is-plasma/2195">Zk-SNARKs for Plasma</a></li>
             </ul>
             <br>
 
             <hr class="hr-dash my-7">
       
             <!-- Plasma MVP -->
-            <h2 id="plasma-mvp"><a href="https://ethresear.ch/t/minimal-viable-plasma/426" target="_blank">Plasma MVP</a></h2>
+            <h2 id="plasma-mvp"><a href="https://ethresear.ch/t/minimal-viable-plasma/426">Plasma MVP</a></h2>
             <p>
               This is a list of research topics that apply mainly to Plasma MVP.
               Some of this research will be useful to other designs, though! 
@@ -354,7 +354,7 @@
             </ul>
             <h6>Resources:</h6>
             <ul>
-              <li><a href="https://ethresear.ch/t/proving-utxo-sum-validity-for-mass-exits/2023" target="_blank">Proving UTXO sum validity for mass exits</a></li>
+              <li><a href="https://ethresear.ch/t/proving-utxo-sum-validity-for-mass-exits/2023">Proving UTXO sum validity for mass exits</a></li>
             </ul>
             <br>
     
@@ -423,7 +423,7 @@
             </ul>
             <h6>Resources:</h6>
             <ul>
-              <li><a href="https://github.com/omisego/research/issues/20" target="_blank">Using Relayers for Order Matching</a></li>
+              <li><a href="https://github.com/omisego/research/issues/20">Using Relayers for Order Matching</a></li>
             </ul>
             <br>
     
@@ -455,16 +455,16 @@
             </ul>
             <h6>Resources:</h6>
             <ul>
-              <li><a href="https://ethresear.ch/t/why-do-dont-we-need-two-phase-sends-plus-confirmation/1866/14?u=kfichter" target="_blank">Why Do We Need Confirmation Signatures?</a></li>
-              <li><a href="https://ethresear.ch/t/plasma-vulnerabiltity-sybil-txs-drained-contract/1654" target="_blank">Confirmation Signatures Must Be Included on the Plasma Chain</a></li>
-              <li><a href="https://ethresear.ch/t/griefing-vectors-in-confirmation-signatures/2301" target="_blank">Griefing Vectors in Confirmation Signatures</a></li>
+              <li><a href="https://ethresear.ch/t/why-do-dont-we-need-two-phase-sends-plus-confirmation/1866/14?u=kfichter">Why Do We Need Confirmation Signatures?</a></li>
+              <li><a href="https://ethresear.ch/t/plasma-vulnerabiltity-sybil-txs-drained-contract/1654">Confirmation Signatures Must Be Included on the Plasma Chain</a></li>
+              <li><a href="https://ethresear.ch/t/griefing-vectors-in-confirmation-signatures/2301">Griefing Vectors in Confirmation Signatures</a></li>
             </ul>
             <br>
 
             <hr class="hr-dash my-7">
       
             <!-- Plasma Cash -->
-            <h2 id="plasma-cash"><a href="https://ethresear.ch/t/plasma-cash-plasma-with-much-less-per-user-data-checking/1298" target="_blank">Plasma Cash</a></h2>
+            <h2 id="plasma-cash"><a href="https://ethresear.ch/t/plasma-cash-plasma-with-much-less-per-user-data-checking/1298">Plasma Cash</a></h2>
             <p>
               Plasma Cash works well for non-fungible tokens.
               Can we extend that so it works well for fungible ones too?
@@ -505,8 +505,8 @@
             </ul>
             <h6>Resources:</h6>
             <ul>
-              <li><a href="https://ethresear.ch/t/one-proposal-for-plasma-cash-with-coin-splitting-and-merging/1447" target="_blank">Proposal for Plasma Cash Splitting and Merging</a></li>
-              <li><a href="https://ethresear.ch/t/plasma-cash-plasma-with-much-less-per-user-data-checking/1298/53" target="_blank">Arbitrary Coin Merging in Plasma Cash</a></li>
+              <li><a href="https://ethresear.ch/t/one-proposal-for-plasma-cash-with-coin-splitting-and-merging/1447">Proposal for Plasma Cash Splitting and Merging</a></li>
+              <li><a href="https://ethresear.ch/t/plasma-cash-plasma-with-much-less-per-user-data-checking/1298/53">Arbitrary Coin Merging in Plasma Cash</a></li>
             </ul>
             <br>
 
@@ -547,8 +547,8 @@
             </ul>
             <h6>Resources:</h6>
             <ul>
-              <li><a href="https://ethresear.ch/t/plasma-xt-plasma-cash-with-much-less-per-user-data-checking/1926" target="_blank">Plasma XT</a></li>
-              <li><a href="https://ethresear.ch/t/plasma-cash-without-any-blockchain-at-all/1974/3" target="_blank">Plasma Cash Without Any Blockchain at All</a></li>
+              <li><a href="https://ethresear.ch/t/plasma-xt-plasma-cash-with-much-less-per-user-data-checking/1926">Plasma XT</a></li>
+              <li><a href="https://ethresear.ch/t/plasma-cash-without-any-blockchain-at-all/1974/3">Plasma Cash Without Any Blockchain at All</a></li>
             </ul>
             <br>
     
@@ -570,7 +570,7 @@
             </p>
             <p>
               Instead, we introduce a new mechanism by which users can explicitly choose to participate in a checkpoint.
-              The details of this mechanism (nicknamed "Plasma XT") are described in <a href="https://ethresear.ch/t/plasma-xt-plasma-cash-with-much-less-per-user-data-checking/1926" target="_blank">this post</a> in <a href="https://ethresear.ch/" target="_blank">ethresear.ch</a>.
+              The details of this mechanism (nicknamed "Plasma XT") are described in <a href="https://ethresear.ch/t/plasma-xt-plasma-cash-with-much-less-per-user-data-checking/1926">this post</a> in <a href="https://ethresear.ch/">ethresear.ch</a>.
             </p>
             <p>
               Plasma XT is a step in the right direction, but it's not totally ideal.
@@ -592,8 +592,8 @@
             </ul>
             <h6>Resources:</h6>
             <ul>
-              <li><a href="https://ethresear.ch/t/plasma-xt-plasma-cash-with-much-less-per-user-data-checking/1926" target="_blank">Plasma XT</a></li>
-              <li><a href="https://ethresear.ch/t/plasma-checkpoint-cost-and-block-time/2016" target="_blank">Plasma checkpoint cost</a></li>
+              <li><a href="https://ethresear.ch/t/plasma-xt-plasma-cash-with-much-less-per-user-data-checking/1926">Plasma XT</a></li>
+              <li><a href="https://ethresear.ch/t/plasma-checkpoint-cost-and-block-time/2016">Plasma checkpoint cost</a></li>
             </ul>
             <br>
           </div>


### PR DESCRIPTION
We started out giving each link `target="_blank"`, but I think that's poor UX. We can let users decide if they want links to open in a new window (ctrl+click).